### PR TITLE
Fix formatTripDirection bug

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -59,10 +59,10 @@ function formatRouteName(route) {
 
 function formatTripDirection(trip) {
   if (trip.direction_id === "1") {
-    return "NB";
+    return "SB";
   }
   else if (trip.direction_id === "0") {
-    return "SB";
+    return "NB";
   }
 }
 


### PR DESCRIPTION
The logic for `formatTripDirection` is wrong. It's displaying NB for southbound trains, and SB for northbound trains. 

Here's a snippet from [data.json](https://github.com/parshap/nextcaltrain/blob/master/data.json) that shows a `direction_id` of 0 is for trains going north, and `direction_id` of 1 for trains going south.

```
{
  route_id: "Li-127",
  service_id: "CT-17APR-Combo-Weekday-01",
  trip_id: "6511465-CT-17APR-Combo-Weekday-01",
  trip_headsign: "San Francisco Caltrain Station",
  trip_short_name: "231",
  direction_id: "0",
  block_id: "",
  shape_id: "cal_sj_sf",
  wheelchair_accessible: "1",
  bikes_allowed: "1"
},
{
  route_id: "Li-127",
  service_id: "CT-17APR-Combo-Weekday-01",
  trip_id: "6511466-CT-17APR-Combo-Weekday-01",
  trip_headsign: "San Jose Caltrain Station",
  trip_short_name: "264",
  direction_id: "1",
  block_id: "",
  shape_id: "cal_sf_sj",
  wheelchair_accessible: "1",
  bikes_allowed: "1"
},
```